### PR TITLE
feat: add search documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules
+static/json

--- a/config.toml
+++ b/config.toml
@@ -9,3 +9,4 @@ canonifyurls = true
   editURL = "https://github.com/matcornic/hugo-learn-doc/edit/master/content/"
   description = "Documentation for Hugo Learn Theme"
   author = "Mathieu Cornic"
+  search = true

--- a/content/basics/installation/index.md
+++ b/content/basics/installation/index.md
@@ -47,6 +47,31 @@ hugo new basics/first-content.md
 hugo new basics/second-content/index.md
 ```
 
+## Enable search functionality
+To use the `search` functionality, you just have to put a `lunr` index which respects this format :
+```json
+[
+    {
+        "uri": "/docs/01-start/index",
+        "title": "Get started",
+        "content": "\n\nGet started\n\nAll you need to know...\n",
+        "tags": ["start", "intro"]
+    },
+    ...
+]
+```
+
+into a `static/json/search.json` file in your hugo project.
+
+And set `search = true` in your config.toml
+
+To generate your lunr index, you can see this project https://github.com/gwleclerc/lunr-hugo which parse your markdown files and extract toml and yaml headers to create index with corresponding format.
+
+In order to generate the index of your static site launch the following comand after installing `lunr-hugo` using `npm`
+```
+    lunr-hugo -i "<content directory>/**/*.md" -o static/json/search.json -l <header format (yaml or toml)>
+```
+
 ## Launching the website
 
 Launch the following command

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,10 @@
 
 echo -e "\033[0;32mDeploying updates to GitHub...\033[0m"
 
+# Build the index.
+npm install
+npm run index
+
 # Build the project.
 hugo
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hugo-learn-doc",
+  "version": "1.0.0",
+  "description": "Official documentation of the hugo-theme-learn",
+  "scripts": {
+    "index": "mkdir -p static/json && lunr-hugo -i 'content/**/*.md' -o static/json/search.json -l yaml"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matcornic/hugo-learn-doc.git"
+  },
+  "keywords": [
+    "lunr"
+  ],
+  "author": "Mathieu Cornic",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/matcornic/hugo-learn-doc/issues"
+  },
+  "homepage": "https://github.com/matcornic/hugo-learn-doc#readme",
+  "devDependencies": {
+    "lunr-hugo": "^0.1.2"
+  }
+}


### PR DESCRIPTION
Waiting to https://github.com/matcornic/hugo-theme-learn/pull/18 to be merged before generate and deploy this documentation on gh-pages branch
